### PR TITLE
Add 24 Hour Average Hashrate

### DIFF
--- a/custom_components/ethermineinfo/const.py
+++ b/custom_components/ethermineinfo/const.py
@@ -21,6 +21,7 @@ ATTR_END_BLOCK = "end_block"
 ATTR_AMOUNT = "amount"
 ATTR_TXHASH = "txhash"
 ATTR_PAID_ON = "paid_on"
+ATTR_AVERAGE_HASHRATE_24h = "average_hashrate_24h"
 
 API_ENDPOINT = "https://api.ethermine.org/miner/"
 

--- a/custom_components/ethermineinfo/sensor.py
+++ b/custom_components/ethermineinfo/sensor.py
@@ -151,11 +151,12 @@ class EthermineInfoSensor(Entity):
                 self._stale_shares = r.json()['data']['currentStatistics']['staleShares']
                 self._unpaid = r.json()['data']['currentStatistics']['unpaid']
                 self._valid_shares = r.json()['data']['currentStatistics']['validShares']
-                self._start_block = r2.json()['data'][0]['start']
-                self._end_block = r2.json()['data'][0]['end']
-                self._amount = r2.json()['data'][0]['amount']
-                self._txhash = r2.json()['data'][0]['txHash']
-                self._paid_on = datetime.fromtimestamp(int(r2.json()['data'][0]['paidOn'])).strftime('%d-%m-%Y %H:%M')
+                if len(r2.json()['data']):
+                    self._start_block = r2.json()['data'][0]['start']
+                    self._end_block = r2.json()['data'][0]['end']
+                    self._amount = r2.json()['data'][0]['amount']
+                    self._txhash = r2.json()['data'][0]['txHash']
+                    self._paid_on = datetime.fromtimestamp(int(r2.json()['data'][0]['paidOn'])).strftime('%d-%m-%Y %H:%M')
             else:
                 raise ValueError()
 


### PR DESCRIPTION
This PR is branched off of my other so includes the fix for no payouts. I have tried to keep the style the same as yours, hope its okay. 

This adds the 24 hr average hashrate from the "/miner/:miner/currentStats" endpoint. Docs here: [https://ethermine.org/api/miner
](https://ethermine.org/api/miner). This value varies from the 6hr one on the dashboard but was easier to get. 

I'd also like to add something to overwrite the name of the sensor so that it doesn't use my wallet address. If this was all okay with you I'll do that in the next day or two... 


